### PR TITLE
enable nebula-cert command, allow hotplug of /etc/nebula

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,18 +34,32 @@ parts:
     build-packages:
       - gcc
 
+plugs:
+  etc-nebula:
+    interface: system-files
+    read:
+      - /etc/nebula
+    write:
+      - /etc/nebula
+
 apps:
   nebula:
+    command: bin/nebula
+    plugs:
+      - network
+      - network-control
+      - etc-nebula
+
+  nebula-cert:
+    command: bin/nebula-cert
+    plugs:
+      - etc-nebula
+
+  run:
     command: bin/nebula -config $SNAP_COMMON/config/config.yaml
     plugs:
       - network
       - network-control
-  
-  cert-ca:
-    command: bin/nebula-cert ca -out-crt $SNAP_COMMON/certs/ca.crt -out-key $SNAP_COMMON/certs/ca.key
-
-  cert-sign:
-    command: bin/nebula-cert sign -ca-crt $SNAP_COMMON/certs/ca.crt -ca-key $SNAP_COMMON/certs/ca.key -out-crt $SNAP_COMMON/certs/nebula-node.crt -out-key $SNAP_COMMON/certs/nebula-node.key
 
   daemon:
     command: bin/nebula -config $SNAP_COMMON/config/config.yaml


### PR DESCRIPTION
One more big change, I noticed in my testing that there was no way to run `nebula-cert` with arbitrary cli arguments. This change enables that functionality, and allows for `/etc/nebula` to be mounted into the snap.

The end result is a `nebula` and a `nebula.nebula-cert` command with a `nebula.run` alias to support backwards compatibility with previous behavior.
```
commands:
  - nebula
  - nebula.nebula-cert
  - nebula.run
services:
  nebula.daemon: simple, enabled, active
```

The file system plug can be used like:
```
sudo snap connect nebula:etc-nebula
```

And example usage on the nebula-cert command.
```
root@nebula-trixie:~# nebula.nebula-cert print -path /var/snap/nebula/common/certs/node.crt 
NebulaCertificate {
        Details {
                Name: trixie-test
                Ips: [
                        192.168.100.123/24
                ]
                Subnets: []
                Groups: [
                        "managed"
                ]
                Not before: 2025-09-08 17:10:52 +0000 UTC
                Not After: 2025-10-08 17:10:52 +0000 UTC
                Is CA: false
                Issuer: REDACTED
                Public key: REDACTED
                Curve: CURVE25519
        }
        Fingerprint: 0454336c09eac253f3574b58e5c06dbeee43f0932f59d198372a4932ec2d63f5
        Signature: 87604896abbd84b6a41ebac86eb7859b44f6278a5be17978c0a70e504aafd3ab08c71f8dfc3e6b1bbbee6fe69274e21f13efd38d9346c3789bc5c5e750707a00
}
```

